### PR TITLE
Adds configuration options for associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ const userSchema = schemaManager.generate(userModel, strategy, {
   title: 'MyUser',
   description: 'My Description',
   exclude: ['someAttribute'],
+  include: ['someAttribute'],
+  associations: true,
+  excludeAssociations: ['someAssociation'],
+  includeAssociations: ['someAssociation'],
 });
 ```
 

--- a/lib/schema-manager.js
+++ b/lib/schema-manager.js
@@ -96,25 +96,19 @@ class SchemaManager {
       );
     });
 
-    // do not add associations if disabled by the user
+    // skip adding associations completely if configured by the user
     if (_modelOptions.get(this).associations === false) {
       return result;
     }
 
     Object.keys(this._getAssociations()).forEach(association => {
-      if (model.associations[association].associationType === 'HasOne') {
-        _.assign(
-          result.properties,
-          _strategy.get(this).getPropertyForHasOneAssociation(association),
-        );
-      }
-
-      if (model.associations[association].associationType === 'HasMany') {
-        _.assign(
-          result.properties,
-          _strategy.get(this).getPropertyForHasManyAssociation(association),
-        );
-      }
+      _.assign(
+        result.properties,
+        this._getModelPropertyForAssociation(
+          association,
+          model.associations[association].associationType,
+        ),
+      );
     });
 
     return result;
@@ -473,6 +467,25 @@ class SchemaManager {
     }
 
     return _strategy.get(this).getPropertyExamples(examples);
+  }
+
+  /**
+   * Returns the property for the given (HasOne or HasMany) association
+   *
+   * @private
+   * @param {Sequelize.Association} association Sequelize Association
+   * @returns {object|null} Object if HasOne or HasMany, null otherwise
+   */
+  _getModelPropertyForAssociation(association, associationType) {
+    if (associationType === 'HasOne') {
+      return _strategy.get(this).getPropertyForHasOneAssociation(association);
+    }
+
+    if (associationType === 'HasMany') {
+      return _strategy.get(this).getPropertyForHasManyAssociation(association);
+    }
+
+    return null;
   }
 }
 

--- a/lib/schema-manager.js
+++ b/lib/schema-manager.js
@@ -61,10 +61,12 @@ class SchemaManager {
    * @param {object} options User options.
    * @param {string} options.title Name to be used as model property 'title'
    * @param {string} options.description Text to be used as model property 'description'
-   * @param {array} options.exclude List of attribute names that will not be excluded from the generated schema
+   * @param {array} options.exclude List of attribute names that will not be included in the generated schema
    * @param {array} options.include List of attribute names that will be included in the generated schema
    * @param {array} options.associations False to exclude all associations from the generated schema, defaults to true
    * @returns {object} Object contaiing the strategy-specific schema
+   * @param {array} options.excludeAssociations List of association names that will not be included in the generated schema
+   * @param {array} options.includeAssociations List of association names that will be included in the generated schema
    */
   generate(model, strategy, options) {
     const defaultOptions = {
@@ -73,6 +75,8 @@ class SchemaManager {
       include: [],
       exclude: [],
       associations: true,
+      includeAssociations: [],
+      excludeAssociations: [],
     };
 
     if (model === undefined) throw new Error('Missing method argument');
@@ -165,6 +169,20 @@ class SchemaManager {
 
     if (typeof options.associations !== 'boolean') {
       throw new TypeError("Model option 'associations' not of type 'boolean'");
+    }
+
+    if (!Array.isArray(options.includeAssociations)) {
+      throw new TypeError("Model option 'includeAssociations' not of type 'array'");
+    }
+
+    if (!Array.isArray(options.excludeAssociations)) {
+      throw new TypeError("Model option option 'excludeAssociations' not of type 'array'");
+    }
+
+    if (options.includeAssociations.length > 0 && options.excludeAssociations.length > 0) {
+      throw new Error(
+        "Model options 'includeAssociations' and 'excludeAssociations' are mutually exclusive",
+      );
     }
 
     _modelOptions.set(this, options);
@@ -470,13 +488,29 @@ class SchemaManager {
   }
 
   /**
-   * Returns the property for the given (HasOne or HasMany) association
+   * Returns the property for the given association.
    *
    * @private
    * @param {Sequelize.Association} association Sequelize Association
-   * @returns {object|null} Object if HasOne or HasMany, null otherwise
+   * @returns {object|null} Object if HasOne or HasMany and not excluded, null otherwise
    */
   _getModelPropertyForAssociation(association, associationType) {
+    const options = _modelOptions.get(this);
+
+    if (
+      options.excludeAssociations.length > 0 &&
+      options.excludeAssociations.includes(association)
+    ) {
+      return null;
+    }
+
+    if (
+      options.includeAssociations.length > 0 &&
+      options.includeAssociations.includes(association) === false
+    ) {
+      return null;
+    }
+
     if (associationType === 'HasOne') {
       return _strategy.get(this).getPropertyForHasOneAssociation(association);
     }

--- a/lib/schema-manager.js
+++ b/lib/schema-manager.js
@@ -63,6 +63,7 @@ class SchemaManager {
    * @param {string} options.description Text to be used as model property 'description'
    * @param {array} options.exclude List of attribute names that will not be excluded from the generated schema
    * @param {array} options.include List of attribute names that will be included in the generated schema
+   * @param {array} options.associations False to exclude all associations from the generated schema, defaults to true
    * @returns {object} Object contaiing the strategy-specific schema
    */
   generate(model, strategy, options) {
@@ -71,6 +72,7 @@ class SchemaManager {
       description: null,
       include: [],
       exclude: [],
+      associations: true,
     };
 
     if (model === undefined) throw new Error('Missing method argument');
@@ -94,7 +96,11 @@ class SchemaManager {
       );
     });
 
-    // add associations
+    // do not add associations if disabled by the user
+    if (_modelOptions.get(this).associations === false) {
+      return result;
+    }
+
     Object.keys(this._getAssociations()).forEach(association => {
       if (model.associations[association].associationType === 'HasOne') {
         _.assign(
@@ -151,16 +157,20 @@ class SchemaManager {
       throw new TypeError("Model option 'description' not of type 'string'");
     }
 
-    if (options.include && !Array.isArray(options.include)) {
+    if (!Array.isArray(options.include)) {
       throw new TypeError("Model option 'exclude' not of type 'array'");
     }
 
-    if (options.exclude && !Array.isArray(options.exclude)) {
+    if (!Array.isArray(options.exclude)) {
       throw new TypeError("Model option option 'exclude' not of type 'array'");
     }
 
     if (options.include.length > 0 && options.exclude.length > 0) {
       throw new Error("Model options 'include' and 'exclude' are mutually exclusive");
+    }
+
+    if (typeof options.associations !== 'boolean') {
+      throw new TypeError("Model option 'associations' not of type 'boolean'");
     }
 
     _modelOptions.set(this, options);

--- a/test/schema-manager.test.js
+++ b/test/schema-manager.test.js
@@ -6,7 +6,7 @@ const { SchemaManager, JsonSchema7Strategy } = require('../lib');
 describe('SchemaManager', function() {
   describe('Test configuration options for the class constructor', function() {
     // ------------------------------------------------------------------------
-    // test default options
+    // test default class options
     // ------------------------------------------------------------------------
     describe('Ensure default values:', function() {
       const schemaManager = new SchemaManager();
@@ -23,7 +23,7 @@ describe('SchemaManager', function() {
     });
 
     // ------------------------------------------------------------------------
-    // test custom baseUri
+    // make sure 'baseUri' works as expected
     // ------------------------------------------------------------------------
     describe('Ensure custom baseUri:', function() {
       const schemaManager = new SchemaManager({
@@ -42,7 +42,7 @@ describe('SchemaManager', function() {
     });
 
     // ------------------------------------------------------------------------
-    // test disabled absolutePaths
+    // make sure disabling 'absolutePaths' renders relative paths
     // ------------------------------------------------------------------------
     describe('Ensure disabled absolutePaths:', function() {
       const schemaManager = new SchemaManager({
@@ -64,7 +64,7 @@ describe('SchemaManager', function() {
 
   describe('Test configuration options for the generate() method', function() {
     // ------------------------------------------------------------------------
-    // test default options
+    // make sure default options render the expected model properties
     // ------------------------------------------------------------------------
     describe('Ensure default model options:', function() {
       const schemaManager = new SchemaManager();
@@ -81,7 +81,7 @@ describe('SchemaManager', function() {
     });
 
     // ------------------------------------------------------------------------
-    // test custom model properties
+    // make sure non-default options render the expected model properties
     // ------------------------------------------------------------------------
     describe('Ensure custom model option:', function() {
       const schemaManager = new SchemaManager();
@@ -102,7 +102,7 @@ describe('SchemaManager', function() {
     });
 
     // ------------------------------------------------------------------------
-    // test attribute exclusion
+    // make sure excluded attributes do not appear in the resultant schema
     // ------------------------------------------------------------------------
     describe('Ensure attribute exclusions:', function() {
       const schemaManager = new SchemaManager();
@@ -125,7 +125,7 @@ describe('SchemaManager', function() {
     });
 
     // ------------------------------------------------------------------------
-    // test attribute inclusion
+    // make sure excluded attributes do appear in the resultant schema
     // ------------------------------------------------------------------------
     describe('Ensure attribute inclusions:', function() {
       const schemaManager = new SchemaManager();
@@ -144,6 +144,39 @@ describe('SchemaManager', function() {
 
       it(`do not include other attributes`, function() {
         expect(Object.keys(schema.properties).length).toBe(4); // 2 left + 1 HasOne + 1 HasMany
+      });
+    });
+
+    // ------------------------------------------------------------------------
+    // make sure the associations options functions as expected
+    // ------------------------------------------------------------------------
+    describe(`Ensure option 'associations' with default value 'true':`, function() {
+      const schemaManager = new SchemaManager();
+      const strategy = new JsonSchema7Strategy();
+      const schema = schemaManager.generate(models.user, strategy);
+
+      it(`generates HasOne association property 'profile`, function() {
+        expect(schema.properties).toHaveProperty('profile');
+      });
+
+      it(`generates HasMany association property 'documents`, function() {
+        expect(schema.properties).toHaveProperty('documents');
+      });
+    });
+
+    describe(`Ensure option 'associations' with user-specificed value 'false':`, function() {
+      const schemaManager = new SchemaManager();
+      const strategy = new JsonSchema7Strategy();
+      const schema = schemaManager.generate(models.user, strategy, {
+        associations: false,
+      });
+
+      it(`does not generate HasOne association property 'profile`, function() {
+        expect(schema.properties.profile).toBeUndefined();
+      });
+
+      it(`does not generate HasMany association property 'documents`, function() {
+        expect(schema.properties.documents).toBeUndefined();
       });
     });
   });

--- a/test/schema-manager.test.js
+++ b/test/schema-manager.test.js
@@ -119,7 +119,7 @@ describe('SchemaManager', function() {
         expect(schema.properties.STRING_1234).toBeUndefined();
       });
 
-      it(`do not exclude other attribues`, function() {
+      it(`do not exclude other attributes`, function() {
         expect(schema.properties).toHaveProperty('id');
       });
     });
@@ -148,18 +148,18 @@ describe('SchemaManager', function() {
     });
 
     // ------------------------------------------------------------------------
-    // make sure the associations options functions as expected
+    // make sure option 'associations' functions as expected
     // ------------------------------------------------------------------------
     describe(`Ensure option 'associations' with default value 'true':`, function() {
       const schemaManager = new SchemaManager();
       const strategy = new JsonSchema7Strategy();
       const schema = schemaManager.generate(models.user, strategy);
 
-      it(`generates HasOne association property 'profile`, function() {
+      it(`generates HasOne association property 'profile'`, function() {
         expect(schema.properties).toHaveProperty('profile');
       });
 
-      it(`generates HasMany association property 'documents`, function() {
+      it(`generates HasMany association property 'documents'`, function() {
         expect(schema.properties).toHaveProperty('documents');
       });
     });
@@ -171,13 +171,51 @@ describe('SchemaManager', function() {
         associations: false,
       });
 
-      it(`does not generate HasOne association property 'profile`, function() {
+      it(`does not generate HasOne association property 'profile'`, function() {
         expect(schema.properties.profile).toBeUndefined();
       });
 
-      it(`does not generate HasMany association property 'documents`, function() {
+      it(`does not generate HasMany association property 'documents'`, function() {
         expect(schema.properties.documents).toBeUndefined();
       });
+    });
+  });
+
+  // ------------------------------------------------------------------------
+  // make sure option 'includeAssociations'functions as expected
+  // ------------------------------------------------------------------------
+  describe('Ensure association inclusions:', function() {
+    const schemaManager = new SchemaManager();
+    const strategy = new JsonSchema7Strategy();
+    const schema = schemaManager.generate(models.user, strategy, {
+      includeAssociations: ['profile'],
+    });
+
+    it(`include association 'profile'`, function() {
+      expect(schema.properties).toHaveProperty('profile');
+    });
+
+    it(`do not include association 'documents'`, function() {
+      expect(schema.properties.documents).toBeUndefined();
+    });
+  });
+
+  // ------------------------------------------------------------------------
+  // make sure option 'excludeAssociations'functions as expected
+  // ------------------------------------------------------------------------
+  describe('Ensure association exclusions:', function() {
+    const schemaManager = new SchemaManager();
+    const strategy = new JsonSchema7Strategy();
+    const schema = schemaManager.generate(models.user, strategy, {
+      excludeAssociations: ['profile'],
+    });
+
+    it(`do not include association 'profile'`, function() {
+      expect(schema.properties.profile).toBeUndefined();
+    });
+
+    it(`include association 'documents'`, function() {
+      expect(schema.properties).toHaveProperty('documents');
     });
   });
 });


### PR DESCRIPTION
```javascript
schemaManager.generate(model, strategy, {
  associations: true, // false to exclude all associations from the generated schema
  includeAssociations: [
    'someAssociation'
  ],
  excludeAssociations: [
    'someAssociation'
  ],
})
```

Please note that `includeAssociations` and `excludeAssociations` are mutually exclusive.