### PR TITLE
fix: arrays not working properly

### DIFF
--- a/lib/type-mapper.js
+++ b/lib/type-mapper.js
@@ -55,7 +55,7 @@ class TypeMapper {
         result = {
           ...ARRAY,
           // Sequelize requires attribute.type to be defined for ARRAYs
-          items: this.map({ type: properties.type.type, allowNull: false }),
+          items: this.map(attributeName, { type: properties.type.type, allowNull: false }, strategy),
         };
         break;
       }
@@ -323,7 +323,7 @@ class TypeMapper {
 
       case 'VIRTUAL': {
         // Use result for the return type (if defined)
-        result = this.map({ ...properties, type: properties.type && properties.type.returnType });
+        result = this.map(attributeName, { ...properties, type: properties.type && properties.type.returnType }, strategy);
         break;
       }
 

--- a/lib/type-mapper.js
+++ b/lib/type-mapper.js
@@ -55,7 +55,11 @@ class TypeMapper {
         result = {
           ...ARRAY,
           // Sequelize requires attribute.type to be defined for ARRAYs
-          items: this.map(attributeName, { type: properties.type.type, allowNull: false }, strategy),
+          items: this.map(
+            attributeName,
+            { type: properties.type.type, allowNull: false },
+            strategy,
+          ),
         };
         break;
       }
@@ -323,7 +327,11 @@ class TypeMapper {
 
       case 'VIRTUAL': {
         // Use result for the return type (if defined)
-        result = this.map(attributeName, { ...properties, type: properties.type && properties.type.returnType }, strategy);
+        result = this.map(
+          attributeName,
+          { ...properties, type: properties.type && properties.type.returnType },
+          strategy,
+        );
         break;
       }
 

--- a/test/models/user.js
+++ b/test/models/user.js
@@ -97,6 +97,26 @@ module.exports = sequelize => {
     };
   }
 
+  if (supportedDataType('ARRAY')) {
+    Model.rawAttributes.ARRAY = {
+      type: DataTypes.ARRAY(DataTypes.INTEGER),
+    };
+  }
+
+  if (supportedDataType('VIRTUAL')) {
+    Model.rawAttributes.VIRTUAL = {
+      type: DataTypes.VIRTUAL(DataTypes.BOOLEAN),
+      get: () => true,
+    };
+
+    Model.rawAttributes.VIRTUAL_DEPENDENCY = {
+      type: new DataTypes.VIRTUAL(DataTypes.INTEGER, ['id']),
+      get() {
+        return this.get('id');
+      },
+    };
+  }
+
   // --------------------------------------------------------------------------
   // Custom options (as specified through `jsonSchema`) starting below.
   // --------------------------------------------------------------------------


### PR DESCRIPTION
bug: using DataType.ARRAY throws a 'cannot read property type of undefined' and breaks

fix: changed the map() call in type-mapper.js to the function's correct call signature; fixed for VIRTUAL as well