### PR TITLE
add recommended rules for eslint-plugin-jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "extends": [
       "airbnb-base",
       "plugin:prettier/recommended",
-      "plugin:unicorn/recommended"
+      "plugin:unicorn/recommended",
+      "plugin:jest/recommended"
     ],
     "env": {
       "browser": false,


### PR DESCRIPTION
This resolves #2 

The rule you were looking for, for you commented out tests was not `no-disabled-tests`, but `no-commented-out-tests`. Adding the recommended jest rules, adds both and plenty more.

I expect this pull request to fail the lint, because the two commented out tests are still left in there:
```
[...]
    // @todo this should be detected by eslint-plugin-jest no-disabled-tests (but is not)
    // test('', function() {
    //   console.log('Does nothing');
    // });

    // @todo add this to the StrategyInterface test suite, it should throw an exception
    // Model.rawAttributes._FAKE_TYPE_ = {
    //   type: "FAKETYPE"
    // };
  });
});

/*
describe('foo', () => {});
*/
```