### PR TITLE
feat: adds option 'secureSchemaUri'

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ To configure global options use the JsonSchemaManager initialization:
 const schemaManager = new JsonSchemaManager({
   baseUri: '/',
   absolutePaths: true,
+  secureSchemaUri: true,
   disableComments: true,
 });
 ```

--- a/examples/generate.js
+++ b/examples/generate.js
@@ -16,6 +16,7 @@ const targetFolder = './examples/';
 const schemaManager = new JsonSchemaManager({
   baseUri: 'https://api.example.com',
   absolutePaths: true,
+  secureSchemaUri: true,
   disableComments: false,
 });
 

--- a/examples/json-schema-v7.md
+++ b/examples/json-schema-v7.md
@@ -1,6 +1,6 @@
 # JSON Schema Draft-07
 
-These schemas were automatically generated on 2020-01-17
+These schemas were automatically generated on 2020-01-25
 using [these Sequelize models](../test/models) and the most recent version of
 sequelize-to-json-schemas. To confirm that these are indeed all valid schemas use:
 
@@ -101,19 +101,53 @@ sequelize-to-json-schemas. To confirm that these are indeed all valid schemas us
     },
     "JSON": {
       "$id": "https://api.example.com/properties/JSON",
+      "anyOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "array"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        }
+      ],
       "type": "object"
     },
     "JSONB_ALLOWNULL": {
       "$id": "https://api.example.com/properties/JSONB_ALLOWNULL",
-        "anyOf": [
-          { "type": "object" },
-          { "type": "array" },
-          { "type": "boolean" },
-          { "type": "integer" },
-          { "type": "number" },
-          { "type": "string" },
-          { "type": "null" }
-        ]
+      "anyOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "array"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "VIRTUAL": {
       "$id": "https://api.example.com/properties/VIRTUAL",
@@ -446,18 +480,52 @@ document (by adding model schemas to `definitions`).
         },
         "JSON": {
           "$id": "https://api.example.com/properties/JSON",
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "array"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ],
           "type": "object"
         },
         "JSONB_ALLOWNULL": {
           "$id": "https://api.example.com/properties/JSONB_ALLOWNULL",
           "anyOf": [
-            { "type": "object" },
-            { "type": "array" },
-            { "type": "boolean" },
-            { "type": "integer" },
-            { "type": "number" },
-            { "type": "string" },
-            { "type": "null" }
+            {
+              "type": "object"
+            },
+            {
+              "type": "array"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
           ]
         },
         "VIRTUAL": {

--- a/examples/openapi-v3.md
+++ b/examples/openapi-v3.md
@@ -1,6 +1,6 @@
 # OpenAPI 3.0
 
-These schemas were automatically generated on 2020-01-17
+These schemas were automatically generated on 2020-01-25
 using [these Sequelize models](../test/models) and the most recent version of
 sequelize-to-json-schemas. To confirm that these are indeed all valid schemas use:
 
@@ -81,16 +81,48 @@ sequelize-to-json-schemas. To confirm that these are indeed all valid schemas us
       "format": "uuid"
     },
     "JSON": {
+      "anyOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "array"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        }
+      ],
       "type": "object"
     },
     "JSONB_ALLOWNULL": {
       "anyOf": [
-        { "type": "object" },
-        { "type": "array" },
-        { "type": "boolean" },
-        { "type": "integer" },
-        { "type": "number" },
-        { "type": "string" }
+        {
+          "type": "object"
+        },
+        {
+          "type": "array"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        }
       ],
       "nullable": true
     },
@@ -384,16 +416,48 @@ example of how to integrate the generated model schemas into a full OpenAPI 3.0 
             "format": "uuid"
           },
           "JSON": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "array"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
             "type": "object"
           },
           "JSONB_ALLOWNULL": {
             "anyOf": [
-              { "type": "object" },
-              { "type": "array" },
-              { "type": "boolean" },
-              { "type": "integer" },
-              { "type": "number" },
-              { "type": "string" }
+              {
+                "type": "object"
+              },
+              {
+                "type": "array"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
             ],
             "nullable": true
           },

--- a/lib/schema-manager.js
+++ b/lib/schema-manager.js
@@ -43,12 +43,14 @@ class SchemaManager {
    * @param {object} options User options.
    * @param {string} options.baseUri Base URI prefixed to generated paths, defaults to '/'
    * @param {string} options.absolutePaths False to generate relative paths, defaults to true
+   * @param {string} options.secureSchemaUri False to render a HTTP link to the strategy-specific schema, defaults to true (HTTPS)
    * @param {string} options.disableComments True to render attribute property 'comment', defaults to false
    */
   constructor(options) {
     const defaultOptions = {
       baseUri: '/',
       absolutePaths: true,
+      secureSchemaUri: true,
       disableComments: true,
     };
 
@@ -142,6 +144,7 @@ class SchemaManager {
     }
 
     checkTypeRequired('absolutePaths', options.absolutePaths, 'boolean');
+    checkTypeRequired('secureSchemaUri', options.secureSchemaUri, 'boolean');
     checkTypeRequired('disableComments', options.disableComments, 'boolean');
 
     _options.set(this, options);
@@ -345,10 +348,11 @@ class SchemaManager {
    * Returns the `schema` property for the model.
    *
    * @private
+   * @param {boolean} secureSchemaUri True for HTTPS, false for HTTP
    * @returns {object}
    */
   _getPropertySchema() {
-    return _strategy.get(this).getPropertySchema();
+    return _strategy.get(this).getPropertySchema(_options.get(this).secureSchemaUri);
   }
 
   /**

--- a/lib/strategies/json-schema-v7.js
+++ b/lib/strategies/json-schema-v7.js
@@ -20,7 +20,7 @@ class JsonSchema7Strategy extends StrategyInterface {
    */
   getPropertySchema(secureSchemaUri) {
     return {
-      $schema: (secureSchemaUri ? 'https' : 'http') + '://json-schema.org/draft-07/schema#',
+      $schema: `${secureSchemaUri ? 'https' : 'http'}://json-schema.org/draft-07/schema#`,
     };
   }
 

--- a/lib/strategies/json-schema-v7.js
+++ b/lib/strategies/json-schema-v7.js
@@ -15,11 +15,12 @@ class JsonSchema7Strategy extends StrategyInterface {
    * {
    *   '$schema': 'https://json-schema.org/draft-07/schema#'
    * }
+   * @param {boolean} secureSchemaUri True for HTTPS, false for HTTP
    * @returns {object}
    */
-  getPropertySchema() {
+  getPropertySchema(secureSchemaUri) {
     return {
-      $schema: 'https://json-schema.org/draft-07/schema#',
+      $schema: (secureSchemaUri ? 'https' : 'http') + '://json-schema.org/draft-07/schema#',
     };
   }
 

--- a/lib/strategies/openapi-v3.js
+++ b/lib/strategies/openapi-v3.js
@@ -11,6 +11,7 @@ class OpenApi3Strategy extends StrategyInterface {
   /**
    * Returns null because OpenAPI 3.0 does not support the "schema" property.
    *
+   * @param {boolean} secureSchemaUri True for HTTPS, false for HTTP
    * @returns {null}
    */
   getPropertySchema() {

--- a/test/schema-manager.test.js
+++ b/test/schema-manager.test.js
@@ -13,6 +13,10 @@ describe('SchemaManager', function() {
       const strategy = new JsonSchema7Strategy();
       const schema = schemaManager.generate(models.user, strategy);
 
+      it(`produce a HTTPS schema URI`, function() {
+        expect(schema.$schema).toEqual('https://json-schema.org/draft-07/schema#');
+      });
+
       it(`produce relative paths for models`, function() {
         expect(schema.$id).toEqual('/user.json');
       });
@@ -23,6 +27,21 @@ describe('SchemaManager', function() {
 
       it(`does not include attribute property '$comment'`, function() {
         expect(schema.properties.CUSTOM_COMMENT.$comment).toBeUndefined();
+      });
+    });
+
+    // ------------------------------------------------------------------------
+    // make sure option 'secureSchemaUri: false` renders a HTTP schema URI
+    // ------------------------------------------------------------------------
+    describe(`Ensure false option 'secureSchemaUri':`, function() {
+      const schemaManager = new JsonSchemaManager({
+        secureSchemaUri: false,
+      });
+      const strategy = new JsonSchema7Strategy();
+      const schema = schemaManager.generate(models.user, strategy);
+
+      it(`includes attribute property '$schema' with HTTP link`, function() {
+        expect(schema.$schema).toEqual('http://json-schema.org/draft-07/schema#');
       });
     });
 


### PR DESCRIPTION
**New** non-breaking `SchemaManager` configuration option:

- `secureSchemaUri: true`: to generate schema links using HTTPS (default)
- `secureSchemaUri: false`: to generate schema links using HTTP

> Please note that this only relates to  the `$schema` property and does not touch `baseUri` (so in theory users could mix http schema with http baseUri).

-----

@brayden-bcgsc thanks for pointing this out, good new option IMO, does this solves your problem?