### PR TITLE
Extend test cases for allowNull

### DIFF
--- a/examples/json-schema-v7.md
+++ b/examples/json-schema-v7.md
@@ -48,8 +48,18 @@ sequelize-to-json-schemas. To confirm that these are indeed all valid schemas us
         "type": "string"
       }
     },
-    "ARRAY_ALLOWNULL": {
-      "$id": "https://api.example.com/properties/ARRAY_ALLOWNULL",
+    "ARRAY_ALLOWNULL_EXPLICIT": {
+      "$id": "https://api.example.com/properties/ARRAY_ALLOWNULL_EXPLICIT",
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "string"
+      }
+    },
+    "ARRAY_ALLOWNULL_IMPLICIT": {
+      "$id": "https://api.example.com/properties/ARRAY_ALLOWNULL_IMPLICIT",
       "type": [
         "array",
         "null"
@@ -73,8 +83,15 @@ sequelize-to-json-schemas. To confirm that these are indeed all valid schemas us
       "type": "string",
       "default": "Default value for STRING"
     },
-    "STRING_ALLOWNULL": {
-      "$id": "https://api.example.com/properties/STRING_ALLOWNULL",
+    "STRING_ALLOWNULL_EXPLICIT": {
+      "$id": "https://api.example.com/properties/STRING_ALLOWNULL_EXPLICIT",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "STRING_ALLOWNULL_IMPLICIT": {
+      "$id": "https://api.example.com/properties/STRING_ALLOWNULL_IMPLICIT",
       "type": [
         "string",
         "null"
@@ -240,8 +257,21 @@ sequelize-to-json-schemas. To confirm that these are indeed all valid schemas us
     "id",
     "createdAt",
     "updatedAt",
+    "ARRAY_INTEGERS",
+    "ARRAY_TEXTS",
+    "CITEXT",
     "INTEGER",
     "STRING",
+    "STRING_1234",
+    "STRING_DOT_BINARY",
+    "TEXT",
+    "UUIDV4",
+    "JSON",
+    "VIRTUAL",
+    "VIRTUAL_DEPENDENCY",
+    "CUSTOM_DESCRIPTION",
+    "CUSTOM_COMMENT",
+    "CUSTOM_EXAMPLES",
     "CUSTOM_READONLY",
     "CUSTOM_WRITEONLY"
   ]
@@ -266,7 +296,10 @@ sequelize-to-json-schemas. To confirm that these are indeed all valid schemas us
     },
     "name": {
       "$id": "https://api.example.com/properties/name",
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "userId": {
       "$id": "https://api.example.com/properties/userId",
@@ -301,7 +334,10 @@ sequelize-to-json-schemas. To confirm that these are indeed all valid schemas us
     },
     "name": {
       "$id": "https://api.example.com/properties/name",
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "userId": {
       "$id": "https://api.example.com/properties/userId",
@@ -336,7 +372,10 @@ sequelize-to-json-schemas. To confirm that these are indeed all valid schemas us
     },
     "name": {
       "$id": "https://api.example.com/properties/name",
-      "type": "string"
+      "type": [
+        "string",
+        "null"
+      ]
     }
   },
   "required": [
@@ -358,17 +397,26 @@ sequelize-to-json-schemas. To confirm that these are indeed all valid schemas us
   "properties": {
     "isBestFriend": {
       "$id": "https://api.example.com/properties/isBestFriend",
-      "type": "boolean",
+      "type": [
+        "boolean",
+        "null"
+      ],
       "default": false
     },
     "userId": {
       "$id": "https://api.example.com/properties/userId",
-      "type": "integer",
+      "type": [
+        "integer",
+        "null"
+      ],
       "format": "int32"
     },
     "friendId": {
       "$id": "https://api.example.com/properties/friendId",
-      "type": "integer",
+      "type": [
+        "integer",
+        "null"
+      ],
       "format": "int32"
     }
   },
@@ -427,8 +475,18 @@ document (by adding model schemas to `definitions`).
             "type": "string"
           }
         },
-        "ARRAY_ALLOWNULL": {
-          "$id": "https://api.example.com/properties/ARRAY_ALLOWNULL",
+        "ARRAY_ALLOWNULL_EXPLICIT": {
+          "$id": "https://api.example.com/properties/ARRAY_ALLOWNULL_EXPLICIT",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "ARRAY_ALLOWNULL_IMPLICIT": {
+          "$id": "https://api.example.com/properties/ARRAY_ALLOWNULL_IMPLICIT",
           "type": [
             "array",
             "null"
@@ -452,8 +510,15 @@ document (by adding model schemas to `definitions`).
           "type": "string",
           "default": "Default value for STRING"
         },
-        "STRING_ALLOWNULL": {
-          "$id": "https://api.example.com/properties/STRING_ALLOWNULL",
+        "STRING_ALLOWNULL_EXPLICIT": {
+          "$id": "https://api.example.com/properties/STRING_ALLOWNULL_EXPLICIT",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "STRING_ALLOWNULL_IMPLICIT": {
+          "$id": "https://api.example.com/properties/STRING_ALLOWNULL_IMPLICIT",
           "type": [
             "string",
             "null"
@@ -619,8 +684,21 @@ document (by adding model schemas to `definitions`).
         "id",
         "createdAt",
         "updatedAt",
+        "ARRAY_INTEGERS",
+        "ARRAY_TEXTS",
+        "CITEXT",
         "INTEGER",
         "STRING",
+        "STRING_1234",
+        "STRING_DOT_BINARY",
+        "TEXT",
+        "UUIDV4",
+        "JSON",
+        "VIRTUAL",
+        "VIRTUAL_DEPENDENCY",
+        "CUSTOM_DESCRIPTION",
+        "CUSTOM_COMMENT",
+        "CUSTOM_EXAMPLES",
         "CUSTOM_READONLY",
         "CUSTOM_WRITEONLY"
       ]
@@ -638,7 +716,10 @@ document (by adding model schemas to `definitions`).
         },
         "name": {
           "$id": "https://api.example.com/properties/name",
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "userId": {
           "$id": "https://api.example.com/properties/userId",
@@ -666,7 +747,10 @@ document (by adding model schemas to `definitions`).
         },
         "name": {
           "$id": "https://api.example.com/properties/name",
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "userId": {
           "$id": "https://api.example.com/properties/userId",
@@ -694,7 +778,10 @@ document (by adding model schemas to `definitions`).
         },
         "name": {
           "$id": "https://api.example.com/properties/name",
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "required": [
@@ -709,17 +796,26 @@ document (by adding model schemas to `definitions`).
       "properties": {
         "isBestFriend": {
           "$id": "https://api.example.com/properties/isBestFriend",
-          "type": "boolean",
+          "type": [
+            "boolean",
+            "null"
+          ],
           "default": false
         },
         "userId": {
           "$id": "https://api.example.com/properties/userId",
-          "type": "integer",
+          "type": [
+            "integer",
+            "null"
+          ],
           "format": "int32"
         },
         "friendId": {
           "$id": "https://api.example.com/properties/friendId",
-          "type": "integer",
+          "type": [
+            "integer",
+            "null"
+          ],
           "format": "int32"
         }
       },

--- a/examples/openapi-v3.md
+++ b/examples/openapi-v3.md
@@ -42,7 +42,14 @@ sequelize-to-json-schemas. To confirm that these are indeed all valid schemas us
         "type": "string"
       }
     },
-    "ARRAY_ALLOWNULL": {
+    "ARRAY_ALLOWNULL_EXPLICIT": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "nullable": true
+    },
+    "ARRAY_ALLOWNULL_IMPLICIT": {
       "type": "array",
       "items": {
         "type": "string"
@@ -61,7 +68,11 @@ sequelize-to-json-schemas. To confirm that these are indeed all valid schemas us
       "type": "string",
       "default": "Default value for STRING"
     },
-    "STRING_ALLOWNULL": {
+    "STRING_ALLOWNULL_EXPLICIT": {
+      "type": "string",
+      "nullable": true
+    },
+    "STRING_ALLOWNULL_IMPLICIT": {
       "type": "string",
       "nullable": true
     },
@@ -203,8 +214,21 @@ sequelize-to-json-schemas. To confirm that these are indeed all valid schemas us
     "id",
     "createdAt",
     "updatedAt",
+    "ARRAY_INTEGERS",
+    "ARRAY_TEXTS",
+    "CITEXT",
     "INTEGER",
     "STRING",
+    "STRING_1234",
+    "STRING_DOT_BINARY",
+    "TEXT",
+    "UUIDV4",
+    "JSON",
+    "VIRTUAL",
+    "VIRTUAL_DEPENDENCY",
+    "CUSTOM_DESCRIPTION",
+    "CUSTOM_COMMENT",
+    "CUSTOM_EXAMPLES",
     "CUSTOM_READONLY",
     "CUSTOM_WRITEONLY"
   ]
@@ -225,7 +249,8 @@ sequelize-to-json-schemas. To confirm that these are indeed all valid schemas us
       "format": "int32"
     },
     "name": {
-      "type": "string"
+      "type": "string",
+      "nullable": true
     },
     "userId": {
       "type": "integer",
@@ -253,7 +278,8 @@ sequelize-to-json-schemas. To confirm that these are indeed all valid schemas us
       "format": "int32"
     },
     "name": {
-      "type": "string"
+      "type": "string",
+      "nullable": true
     },
     "userId": {
       "type": "integer",
@@ -281,7 +307,8 @@ sequelize-to-json-schemas. To confirm that these are indeed all valid schemas us
       "format": "int32"
     },
     "name": {
-      "type": "string"
+      "type": "string",
+      "nullable": true
     }
   },
   "required": [
@@ -301,15 +328,18 @@ sequelize-to-json-schemas. To confirm that these are indeed all valid schemas us
   "properties": {
     "isBestFriend": {
       "type": "boolean",
+      "nullable": true,
       "default": false
     },
     "userId": {
       "type": "integer",
-      "format": "int32"
+      "format": "int32",
+      "nullable": true
     },
     "friendId": {
       "type": "integer",
-      "format": "int32"
+      "format": "int32",
+      "nullable": true
     }
   },
   "required": [
@@ -377,7 +407,14 @@ example of how to integrate the generated model schemas into a full OpenAPI 3.0 
               "type": "string"
             }
           },
-          "ARRAY_ALLOWNULL": {
+          "ARRAY_ALLOWNULL_EXPLICIT": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "ARRAY_ALLOWNULL_IMPLICIT": {
             "type": "array",
             "items": {
               "type": "string"
@@ -396,7 +433,11 @@ example of how to integrate the generated model schemas into a full OpenAPI 3.0 
             "type": "string",
             "default": "Default value for STRING"
           },
-          "STRING_ALLOWNULL": {
+          "STRING_ALLOWNULL_EXPLICIT": {
+            "type": "string",
+            "nullable": true
+          },
+          "STRING_ALLOWNULL_IMPLICIT": {
             "type": "string",
             "nullable": true
           },
@@ -538,8 +579,21 @@ example of how to integrate the generated model schemas into a full OpenAPI 3.0 
           "id",
           "createdAt",
           "updatedAt",
+          "ARRAY_INTEGERS",
+          "ARRAY_TEXTS",
+          "CITEXT",
           "INTEGER",
           "STRING",
+          "STRING_1234",
+          "STRING_DOT_BINARY",
+          "TEXT",
+          "UUIDV4",
+          "JSON",
+          "VIRTUAL",
+          "VIRTUAL_DEPENDENCY",
+          "CUSTOM_DESCRIPTION",
+          "CUSTOM_COMMENT",
+          "CUSTOM_EXAMPLES",
           "CUSTOM_READONLY",
           "CUSTOM_WRITEONLY"
         ]
@@ -553,7 +607,8 @@ example of how to integrate the generated model schemas into a full OpenAPI 3.0 
             "format": "int32"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "userId": {
             "type": "integer",
@@ -574,7 +629,8 @@ example of how to integrate the generated model schemas into a full OpenAPI 3.0 
             "format": "int32"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "userId": {
             "type": "integer",
@@ -595,7 +651,8 @@ example of how to integrate the generated model schemas into a full OpenAPI 3.0 
             "format": "int32"
           },
           "name": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           }
         },
         "required": [
@@ -608,15 +665,18 @@ example of how to integrate the generated model schemas into a full OpenAPI 3.0 
         "properties": {
           "isBestFriend": {
             "type": "boolean",
+            "nullable": true,
             "default": false
           },
           "userId": {
             "type": "integer",
-            "format": "int32"
+            "format": "int32",
+            "nullable": true
           },
           "friendId": {
             "type": "integer",
-            "format": "int32"
+            "format": "int32",
+            "nullable": true
           }
         },
         "required": [

--- a/lib/strategy-interface.js
+++ b/lib/strategy-interface.js
@@ -11,6 +11,7 @@ class StrategyInterface {
    * Must return the property used as "schema".
    *
    * @see {@link https://json-schema.org/understanding-json-schema/reference/schema.html#schema}
+   * @param {boolean} secureSchemaUri True for HTTPS, false for HTTP
    * @returns {object|null} Null to omit property from the result
    */
   getPropertySchema() {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-unicorn": "^15.0.0",
     "fs": "0.0.1-security",
-    "husky": "^4.0.2",
+    "husky": "^4.2.1",
     "jest": "^24.9.0",
     "jsdoc": "^3.6.3",
     "lint-staged": "^9.5.0",

--- a/test/models/user.js
+++ b/test/models/user.js
@@ -47,9 +47,13 @@ module.exports = (sequelize, { DataTypes }) => {
       allowNull: false,
     };
 
-    Model.rawAttributes.ARRAY_ALLOWNULL = {
+    Model.rawAttributes.ARRAY_ALLOWNULL_EXPLICIT = {
       type: DataTypes.ARRAY(DataTypes.TEXT),
       allowNull: true,
+    };
+
+    Model.rawAttributes.ARRAY_ALLOWNULL_IMPLICIT = {
+      type: DataTypes.ARRAY(DataTypes.TEXT),
     };
   }
 
@@ -75,9 +79,13 @@ module.exports = (sequelize, { DataTypes }) => {
       defaultValue: 'Default value for STRING',
     };
 
-    Model.rawAttributes.STRING_ALLOWNULL = {
+    Model.rawAttributes.STRING_ALLOWNULL_EXPLICIT = {
       type: DataTypes.STRING,
       allowNull: true,
+    };
+
+    Model.rawAttributes.STRING_ALLOWNULL_IMPLICIT = {
+      type: DataTypes.STRING,
     };
 
     Model.rawAttributes.STRING_1234 = {

--- a/test/schema-manager.test.js
+++ b/test/schema-manager.test.js
@@ -102,7 +102,7 @@ describe('SchemaManager', function() {
 
   describe('Test configuration options for the generate() method', function() {
     // ------------------------------------------------------------------------
-    // make sure default options render the expected model properties
+    // make sure default MODEL options render the expected MODEL properties
     // ------------------------------------------------------------------------
     describe('Ensure default model options:', function() {
       const schemaManager = new JsonSchemaManager();

--- a/test/strategies/json-schema-v7-strategy.test.js
+++ b/test/strategies/json-schema-v7-strategy.test.js
@@ -91,7 +91,10 @@ describe('JsonSchema7Strategy', function() {
         });
 
         it("has property 'type' with two values named 'array' and 'null'", function() {
-          expect(Object.values(schema.properties.ARRAY_ALLOWNULL_EXPLICIT.type)).toEqual(['array', 'null']);
+          expect(Object.values(schema.properties.ARRAY_ALLOWNULL_EXPLICIT.type)).toEqual([
+            'array',
+            'null',
+          ]);
         });
       });
 
@@ -101,7 +104,10 @@ describe('JsonSchema7Strategy', function() {
         });
 
         it("has property 'type' with two values named 'array' and 'null'", function() {
-          expect(Object.values(schema.properties.ARRAY_ALLOWNULL_IMPLICIT.type)).toEqual(['array', 'null']);
+          expect(Object.values(schema.properties.ARRAY_ALLOWNULL_IMPLICIT.type)).toEqual([
+            'array',
+            'null',
+          ]);
         });
       });
     });

--- a/test/strategies/json-schema-v7-strategy.test.js
+++ b/test/strategies/json-schema-v7-strategy.test.js
@@ -40,13 +40,28 @@ describe('JsonSchema7Strategy', function() {
     // make sure sequelize DataTypes render as expected
     // ------------------------------------------------------------------------
     describe('Ensure Sequelize DataTypes are properly converted and thus:', function() {
-      describe('STRING_ALLOWNULL', function() {
+      describe('STRING_ALLOWNULL_EXPLICIT', function() {
         it("has property 'type' of type 'array'", function() {
-          expect(Array.isArray(schema.properties.STRING_ALLOWNULL.type)).toBe(true);
+          expect(Array.isArray(schema.properties.STRING_ALLOWNULL_EXPLICIT.type)).toBe(true);
         });
 
         it("has property 'type' with two values named 'string' and 'null'", function() {
-          expect(Object.values(schema.properties.STRING_ALLOWNULL.type)).toEqual([
+          expect(Object.values(schema.properties.STRING_ALLOWNULL_EXPLICIT.type)).toEqual([
+            'string',
+            'null',
+          ]);
+        });
+      });
+
+      // Sequelize allows null values by default so we need to make sure rendered schema
+      // keys allow null by default (even when not explicitely setting `allowNull: true`)
+      describe('STRING_ALLOWNULL_IMPLICIT', function() {
+        it("has property 'type' of type 'array'", function() {
+          expect(Array.isArray(schema.properties.STRING_ALLOWNULL_IMPLICIT.type)).toBe(true);
+        });
+
+        it("has property 'type' with two values named 'string' and 'null'", function() {
+          expect(Object.values(schema.properties.STRING_ALLOWNULL_IMPLICIT.type)).toEqual([
             'string',
             'null',
           ]);
@@ -70,13 +85,23 @@ describe('JsonSchema7Strategy', function() {
         });
       });
 
-      describe('ARRAY_ALLOWNULL', function() {
+      describe('ARRAY_ALLOWNULL_EXPLICIT', function() {
         it("has property 'type' of type 'array'", function() {
-          expect(Array.isArray(schema.properties.ARRAY_ALLOWNULL.type)).toBe(true);
+          expect(Array.isArray(schema.properties.ARRAY_ALLOWNULL_EXPLICIT.type)).toBe(true);
         });
 
         it("has property 'type' with two values named 'array' and 'null'", function() {
-          expect(Object.values(schema.properties.ARRAY_ALLOWNULL.type)).toEqual(['array', 'null']);
+          expect(Object.values(schema.properties.ARRAY_ALLOWNULL_EXPLICIT.type)).toEqual(['array', 'null']);
+        });
+      });
+
+      describe('ARRAY_ALLOWNULL_IMPLICIT', function() {
+        it("has property 'type' of type 'array'", function() {
+          expect(Array.isArray(schema.properties.ARRAY_ALLOWNULL_IMPLICIT.type)).toBe(true);
+        });
+
+        it("has property 'type' with two values named 'array' and 'null'", function() {
+          expect(Object.values(schema.properties.ARRAY_ALLOWNULL_IMPLICIT.type)).toEqual(['array', 'null']);
         });
       });
     });

--- a/test/strategies/openapi-v3-stragegy.test.js
+++ b/test/strategies/openapi-v3-stragegy.test.js
@@ -26,13 +26,25 @@ describe('OpenApi3Strategy', function() {
     // make sure sequelize DataTypes render as expected
     // ------------------------------------------------------------------------
     describe('Ensure Sequelize DataTypes are properly converted and thus:', function() {
-      describe('STRING_ALLOWNULL', function() {
+      describe('STRING_ALLOWNULL_EXPLICIT', function() {
         it("has property 'type' of type 'string'", function() {
-          expect(schema.properties.STRING_ALLOWNULL.type).toEqual('string');
+          expect(schema.properties.STRING_ALLOWNULL_EXPLICIT.type).toEqual('string');
         });
 
         it("has property 'nullable' of type 'boolean'", function() {
-          expect(typeof schema.properties.STRING_ALLOWNULL.nullable).toEqual('boolean');
+          expect(typeof schema.properties.STRING_ALLOWNULL_EXPLICIT.nullable).toEqual('boolean');
+        });
+      });
+
+      // Sequelize allows null values by default so we need to make sure rendered schema
+      // keys allow null by default (even when not explicitely setting `allowNull: true`)
+      describe('STRING_ALLOWNULL_IMPLICIT', function() {
+        it("has property 'type' of type 'string'", function() {
+          expect(schema.properties.STRING_ALLOWNULL_IMPLICIT.type).toEqual('string');
+        });
+
+        it("has property 'nullable' of type 'boolean'", function() {
+          expect(typeof schema.properties.STRING_ALLOWNULL_IMPLICIT.nullable).toEqual('boolean');
         });
       });
 
@@ -53,13 +65,23 @@ describe('OpenApi3Strategy', function() {
         });
       });
 
-      describe('ARRAY_ALLOWNULL', function() {
+      describe('ARRAY_ALLOWNULL_EXPLICIT', function() {
         it("has property 'type' of type 'string'", function() {
-          expect(schema.properties.ARRAY_ALLOWNULL.type).toEqual('array');
+          expect(schema.properties.ARRAY_ALLOWNULL_EXPLICIT.type).toEqual('array');
         });
 
         it("has property 'nullable' of type 'boolean'", function() {
-          expect(typeof schema.properties.ARRAY_ALLOWNULL.nullable).toEqual('boolean');
+          expect(typeof schema.properties.ARRAY_ALLOWNULL_EXPLICIT.nullable).toEqual('boolean');
+        });
+      });
+
+      describe('ARRAY_ALLOWNULL_IMPLICIT', function() {
+        it("has property 'type' of type 'string'", function() {
+          expect(schema.properties.ARRAY_ALLOWNULL_IMPLICIT.type).toEqual('array');
+        });
+
+        it("has property 'nullable' of type 'boolean'", function() {
+          expect(typeof schema.properties.ARRAY_ALLOWNULL_IMPLICIT.nullable).toEqual('boolean');
         });
       });
     });


### PR DESCRIPTION
Refs #55 

@brayden-bcgsc it looks like I'm seeing an unexpected side-effect of your PR, would you please review? 

### Situation

In the rendered examples (`npm run examples`):

- the list of required fields has changed
- looks like `allowNull: false` now implicitely makes the field required

### To be answered

I wonder if this is desired, I can imagine having fields that are not required BUT when they are present they may not be null. 