### PR TITLE
Add support for array of enums

### DIFF
--- a/examples/json-schema-v7.md
+++ b/examples/json-schema-v7.md
@@ -1,6 +1,6 @@
 # JSON Schema Draft-07
 
-These schemas were automatically generated on 2020-11-28
+These schemas were automatically generated on 2021-02-23
 using [these Sequelize models](../test/models) and the most recent version of
 sequelize-to-json-schemas. To confirm that these are indeed all valid schemas use:
 
@@ -66,6 +66,17 @@ sequelize-to-json-schemas. To confirm that these are indeed all valid schemas us
       ],
       "items": {
         "type": "string"
+      }
+    },
+    "ARRAY_ENUM_STRINGS": {
+      "$id": "https://api.example.com/properties/ARRAY_ENUM_STRINGS",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "hello",
+          "world"
+        ]
       }
     },
     "BLOB": {
@@ -264,6 +275,7 @@ sequelize-to-json-schemas. To confirm that these are indeed all valid schemas us
     "updatedAt",
     "ARRAY_INTEGERS",
     "ARRAY_TEXTS",
+    "ARRAY_ENUM_STRINGS",
     "BLOB",
     "CITEXT",
     "INTEGER",
@@ -501,6 +513,17 @@ document (by adding model schemas to `definitions`).
             "type": "string"
           }
         },
+        "ARRAY_ENUM_STRINGS": {
+          "$id": "https://api.example.com/properties/ARRAY_ENUM_STRINGS",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "hello",
+              "world"
+            ]
+          }
+        },
         "BLOB": {
           "$id": "https://api.example.com/properties/BLOB",
           "type": "string",
@@ -697,6 +720,7 @@ document (by adding model schemas to `definitions`).
         "updatedAt",
         "ARRAY_INTEGERS",
         "ARRAY_TEXTS",
+        "ARRAY_ENUM_STRINGS",
         "BLOB",
         "CITEXT",
         "INTEGER",

--- a/examples/openapi-v3.md
+++ b/examples/openapi-v3.md
@@ -1,6 +1,6 @@
 # OpenAPI 3.0
 
-These schemas were automatically generated on 2020-11-28
+These schemas were automatically generated on 2021-02-23
 using [these Sequelize models](../test/models) and the most recent version of
 sequelize-to-json-schemas. To confirm that these are indeed all valid schemas use:
 
@@ -55,6 +55,16 @@ sequelize-to-json-schemas. To confirm that these are indeed all valid schemas us
         "type": "string"
       },
       "nullable": true
+    },
+    "ARRAY_ENUM_STRINGS": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "hello",
+          "world"
+        ]
+      }
     },
     "BLOB": {
       "type": "string",
@@ -220,6 +230,7 @@ sequelize-to-json-schemas. To confirm that these are indeed all valid schemas us
     "updatedAt",
     "ARRAY_INTEGERS",
     "ARRAY_TEXTS",
+    "ARRAY_ENUM_STRINGS",
     "BLOB",
     "CITEXT",
     "INTEGER",
@@ -426,6 +437,16 @@ example of how to integrate the generated model schemas into a full OpenAPI 3.0 
             },
             "nullable": true
           },
+          "ARRAY_ENUM_STRINGS": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "hello",
+                "world"
+              ]
+            }
+          },
           "BLOB": {
             "type": "string",
             "format": "byte"
@@ -590,6 +611,7 @@ example of how to integrate the generated model schemas into a full OpenAPI 3.0 
           "updatedAt",
           "ARRAY_INTEGERS",
           "ARRAY_TEXTS",
+          "ARRAY_ENUM_STRINGS",
           "BLOB",
           "CITEXT",
           "INTEGER",

--- a/lib/type-mapper.js
+++ b/lib/type-mapper.js
@@ -144,7 +144,7 @@ class TypeMapper {
       // ENUM('value 1', 'value 2')
       // ----------------------------------------------------------------------
       case 'ENUM': {
-        result = { ...STRING, enum: [...properties.values] };
+        result = { ...STRING, enum: [...(properties.values || properties.options.values)] };
         break;
       }
 

--- a/lib/type-mapper.js
+++ b/lib/type-mapper.js
@@ -144,7 +144,7 @@ class TypeMapper {
       // ENUM('value 1', 'value 2')
       // ----------------------------------------------------------------------
       case 'ENUM': {
-        result = { ...STRING, enum: [...(properties.values || properties.options.values)] };
+        result = { ...STRING, enum: [...(properties.values || properties.type.values)] };
         break;
       }
 

--- a/lib/type-mapper.js
+++ b/lib/type-mapper.js
@@ -46,7 +46,6 @@ class TypeMapper {
     // convert DataType to `type` property
     switch (attributeType) {
       // ----------------------------------------------------------------------
-      // @todo Sequelize.ARRAY(Sequelize.ENUM)
       // @todo Sequelize.ARRAY(Sequelize.RANGE(Sequelize.DATE))
       // ----------------------------------------------------------------------
       case 'ARRAY': {

--- a/test/models/user.js
+++ b/test/models/user.js
@@ -55,6 +55,13 @@ module.exports = (sequelize, { DataTypes }) => {
     Model.rawAttributes.ARRAY_ALLOWNULL_IMPLICIT = {
       type: DataTypes.ARRAY(DataTypes.TEXT),
     };
+
+    if (supportedDataType('ENUM')) {
+      Model.rawAttributes.ARRAY_ENUM_STRINGS = {
+        type: DataTypes.ARRAY(DataTypes.ENUM('hello', 'world')),
+        allowNull: false,
+      };
+    }
   }
 
   if (supportedDataType('BLOB')) {

--- a/test/strategy-interface.test.js
+++ b/test/strategy-interface.test.js
@@ -135,6 +135,20 @@ describe('StrategyInterface', function () {
           expect(schema.properties.ARRAY_TEXTS.items.type).toEqual('string');
         });
       });
+
+      if (supportedDataType('ENUM')) {
+        describe('ARRAY_ENUM_STRINGS', function () {
+          it("has property 'type' of tyoe 'array", function () {
+            expect(schema.properties.ARRAY_ENUM_STRINGS.type).toEqual('array');
+          });
+          it("has property 'items.type' with value 'string'", function () {
+            expect(schema.properties.ARRAY_ENUM_STRINGS.items.type).toEqual('string');
+          });
+          it("has property 'items.enum' with length > 0", function () {
+            expect(schema.properties.ARRAY_ENUM_STRINGS.items.enum.length).toBeGreaterThan(0);
+          });
+        });
+      }
     }
 
     if (supportedDataType('CITEXT')) {


### PR DESCRIPTION
An `ARRAY` type is processed as follows:
```javascript
      case 'ARRAY': {
        result = {
          ...ARRAY,
          // Sequelize requires attribute.type to be defined for ARRAYs
          items: this.map(
            attributeName,
            { type: properties.type.type, allowNull: false },
            strategy,
          ),
        };
        break;
      }
```
So the only available keys in `properties` are `type` and `allowNull`, and if the type is `ENUM`, an undefined property `values` is being spread:
```javascript
      case 'ENUM': {
        result = { ...STRING, enum: [...properties.values] };
        break;
      }
```
Which causes an exception. The simplest apparent fix for that is
```javascript
      case 'ENUM': {
        result = { ...STRING, enum: [...(properties.values || properties.type.values)] };
        break;
      }
```